### PR TITLE
Reuse parsed org name instead of hardcoded one, fix dict lookups

### DIFF
--- a/projectsmigrator.py
+++ b/projectsmigrator.py
@@ -97,7 +97,7 @@ def merge_workspaces(project_url, workspace, field, **args):
     cursor = None
     print("Reading Project", end="")
     while True:
-        res = gh_query(gh_proj_items, dict(login="pretagov", number=int(proj_num), cursor=cursor))[
+        res = gh_query(gh_proj_items, dict(login=org_name, number=int(proj_num), cursor=cursor))[
             "organization"
         ]["projectV2"]["items"]
         items.extend(res["nodes"])


### PR DESCRIPTION
This enables using the script outside of the "pretagov" org, and fixes some areas where dict lookups are potentially None.